### PR TITLE
Use var instead of let and const

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,42 +1,38 @@
 $(document).ready(function() {
-  const BUILD_ENDPOINT = `${BINDERHUB_HOST}/build/gh`;
+  var BUILD_ENDPOINT = BINDERHUB_HOST + '/build/gh';
 
-  $(".launch-item").click(function(event) {
-    let name = $(event.currentTarget).data("example-name");
-    let repoUrl = $(event.currentTarget).data("example-repo-url");
-    let url = $(event.currentTarget).data("example-url");
-    let ref = $(event.currentTarget).data("example-ref");
+  $('.launch-item').click(function(event) {
+    var name = $(event.currentTarget).data('example-name');
+    var repoUrl = $(event.currentTarget).data('example-repo-url');
+    var url = $(event.currentTarget).data('example-url');
+    var ref = $(event.currentTarget).data('example-ref');
 
     // strip github.com from the repo url
     // TODO: handle other sources
-    repoUrl = repoUrl.replace("https://github.com/", "");
+    repoUrl = repoUrl.replace('https://github.com/', '');
 
-    const buildUrl = `${BUILD_ENDPOINT}/${repoUrl}/${ref}?urlpath=${url}`;
-
-    $("#loading_modal").modal({
-      backdrop: "static",
+    $('#loading_modal').modal({
+      backdrop: 'static',
       keyboard: false,
       show: true
     });
 
-    $("#loader_text").html("Launching " + name);
+    $('#loader_text').html('Launching ' + name);
 
-    // TODO: reuse the same logic as in:
-    // https://github.com/jupyterhub/binderhub/tree/master/binderhub/static/js/src
-    const evtSource = new EventSource(buildUrl);
+    var buildUrl = BUILD_ENDPOINT + '/' + repoUrl + '/' + ref + '?urlpath=' + url;
+    var evtSource = new EventSource(buildUrl);
     evtSource.onmessage = function(event) {
-      const data = JSON.parse(event.data);
-      $("#loader_text").html(data.phase);
-      if (data.phase === "ready") {
+      var data = JSON.parse(event.data);
+      $('#loader_text').html(data.phase);
+      if (data.phase === 'ready') {
         evtSource.close();
-        const redirectUrl = data.url;
-        const token = data.token;
-        const redirect = `${redirectUrl}${url}?token=${token}`;
-        $("#loader_text").html("Launching");
+        var redirectUrl = data.url;
+        var token = data.token;
+        var redirect = redirectUrl + url + '?token=' + token;
+        $('#loader_text').html('Launching');
         window.location.href = redirect;
       }
     };
-
     return false;
   });
 });


### PR DESCRIPTION
Since there is no Webpack step for now, and the JS logic is still simple, let's default using to `var` instead of `let` and `const`.

Let's also remove template literals as this is a ES 2015 feature.