### PR TITLE
Add workflow to build the examples

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.8'
+        architecture: 'x64'
+    - name: Install the dependencies
+      run: python -m pip install -r scripts/requirements.txt
+    - name: Build the binders
+      run: |
+        python scripts/build.py

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: master
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,62 @@
+"""
+Build all the examples.
+
+This script goes through all the examples in the gallery,
+and calls the BinderHub /build endpoint to make sure the
+examples are built.
+
+Inspired by: https://github.com/jupyterhub/binderhub/blob/master/examples/binder-api.py#L18-L34
+
+TODO: use an endpoint to know if the image is built if/when it gets added to BinderHub
+Related issue: https://github.com/jupyterhub/binderhub/issues/998
+"""
+
+import json
+
+from pathlib import Path
+
+import requests
+import yaml
+
+HERE = Path(".")
+BINDER_URL = "https://mybinder.org"
+DEFAULT_REF = "master"
+
+# wait 10 minutes for each build
+TIMEOUT = 60 * 10
+
+
+def build_binder(repo, ref):
+    url = f"{BINDER_URL}/build/gh/{repo}/{ref}"
+    r = requests.get(url, stream=True, timeout=TIMEOUT)
+    r.raise_for_status()
+    for line in r.iter_lines():
+        line = line.decode("utf8", "replace")
+        if not line.startswith("data:"):
+            continue
+
+        data = json.loads(line.split(":", 1)[1])
+        phase = data.get("phase", "")
+        if not phase:
+            continue
+
+        if phase == "built":
+            r.close()
+            return
+
+
+def build_all():
+    gallery = HERE.parent / "_data/gallery.yaml"
+    with open(gallery, "r") as f:
+        examples = yaml.safe_load(f)
+
+    for example in examples:
+        repo = example.get("repo_url").replace("https://github.com/", "")
+        ref = example.get("ref", DEFAULT_REF)
+
+        print(f"Building a binder for {repo}@{ref}")
+        build_binder(repo, ref)
+
+
+if __name__ == "__main__":
+    build_all()

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+requests


### PR DESCRIPTION
Fixes #4.

Add a Python script and GitHub Actions workflow to make sure the examples are built on mybinder.org.

Ideally we would use a different endpoint to check whether a binder is already built (see https://github.com/jupyterhub/binderhub/issues/998). The current approach might still launch actual pods / notebook servers when using the `/build` endpoint.

In follow-up PRs, we could consider splitting the example into different files, and trigger a check a the newly added example to make sure it is built.

### TODO

- [x] Add the build script
- [x] Add the GH actions workflow
- [x] Remove the trigger on `pull_request` (to be handled later)