### PR TITLE
Added Citi Bike Clustergrammer2-Bqplot Dashboard

### DIFF
--- a/_data/gallery.yaml
+++ b/_data/gallery.yaml
@@ -95,3 +95,11 @@
   repo_url: https://github.com/voila-gallery/voila-spotify
   ref: 625f0d3eb7472db4f355fdd8ab522c5bebf291c7
   image_url: https://github.com/voila-gallery/voila-spotify/raw/master/thumbnail.png
+  
+  
+- title: citibike-clustergrammer2
+  description: Citi Bike Data Visualization using Clustergrammer2 and Bqplot
+  url: voila/render/index.ipynb
+  ref: c3eccddc558722522ed5aa32afcbfc32ee7297d0
+  repo_url: https://github.com/cornhundred/citibike-clustergrammer2
+  image_url: https://raw.githubusercontent.com/cornhundred/citibike-clustergrammer2/blob/master/img/small_gif.gif


### PR DESCRIPTION
Hi, this is another new example of how we can use the interactive WebGL heatmap Jupyter Widget Clustergrammer2 to explore high-dimensional spatial data - this time from NYC Citi Bike. We hierarchically cluster stations based on their destination distributions (2.18 million rides from July 2019), show station location, show UMAP of stations, etc.

If this is too many similar examples on the gallery, we can drop the CODEX example since it is pretty redundant with the Visium spatial transcriptomics example. 