### PR TITLE
Use HEAD reference for the country indicator repo

### DIFF
--- a/_data/gallery.yaml
+++ b/_data/gallery.yaml
@@ -2,7 +2,7 @@
   description: Explore the correlations between indicators of development using matplotlib and ipywidgets
   url: voila/render/index.ipynb
   repo_url: https://github.com/binder-examples/voila
-  ref: f77719dc1592a30500a303aae1b9ef0aedf29729
+  ref: HEAD
   image_url: https://i.imgur.com/IeG75O3.png
 
 - title: gaussian-density


### PR DESCRIPTION
So it doesn't require updating the ref when new changes are merged in the repo.