### PR TITLE
radiation notebook example added

### DIFF
--- a/_data/gallery.yaml
+++ b/_data/gallery.yaml
@@ -141,6 +141,6 @@
 - title: Radiation-Map
   description: Radiation map produced with data from the nuclear safety institute
   url: voila/render/Radiation.ipynb
-  ref: 70febf67a25797d9af14fbb7ea47d6563bcb3fc6
+  ref: 6a665e3648fe81436cf0af8b23c439e204042a85
   repo_url: https://github.com/MackyDIARRA/radiation.git
-  image_url: https://upload.wikimedia.org/wikipedia/commons/0/03/Radiation_warning_symbol.png
+  image_url: https://user-images.githubusercontent.com/2397974/77835548-2166e280-714e-11ea-8ad4-fa5e5319b484.png

--- a/_data/gallery.yaml
+++ b/_data/gallery.yaml
@@ -137,3 +137,10 @@
   ref: 7c017f0c6f3228948d35bcd5b2d3e93215951239
   repo_url: https://github.com/zolabar/Conformal-Maps
   image_url: https://github.com/zolabar/Conformal-Maps/raw/master/docs/source/GUI_cfmp.PNG
+
+- title: Radiation-Map
+  description: Radiation map produced with data from the nuclear safety institute
+  url: voila/render/Radiation.ipynb
+  ref: 70febf67a25797d9af14fbb7ea47d6563bcb3fc6
+  repo_url: https://github.com/MackyDIARRA/radiation.git
+  image_url: https://upload.wikimedia.org/wikipedia/commons/0/03/Radiation_warning_symbol.png

--- a/_data/gallery.yaml
+++ b/_data/gallery.yaml
@@ -141,6 +141,6 @@
 - title: Radiation-Map
   description: Radiation map produced with data from the nuclear safety institute
   url: voila/render/Radiation.ipynb
-  ref: c1f8ae098a0b1ad1390bcd75d4419508a7bd0219
-  repo_url: https://github.com/MackyDIARRA/radiation.git
+  ref: a3fd14983c9152132052bf352fbdbf69492feef3
+  repo_url: https://github.com/MackyDIARRA/radiation
   image_url: https://user-images.githubusercontent.com/2397974/77835548-2166e280-714e-11ea-8ad4-fa5e5319b484.png

--- a/_data/gallery.yaml
+++ b/_data/gallery.yaml
@@ -141,6 +141,6 @@
 - title: Radiation-Map
   description: Radiation map produced with data from the nuclear safety institute
   url: voila/render/Radiation.ipynb
-  ref: 6a665e3648fe81436cf0af8b23c439e204042a85
+  ref: c1f8ae098a0b1ad1390bcd75d4419508a7bd0219
   repo_url: https://github.com/MackyDIARRA/radiation.git
   image_url: https://user-images.githubusercontent.com/2397974/77835548-2166e280-714e-11ea-8ad4-fa5e5319b484.png


### PR DESCRIPTION
I modified the environment.yml file in order to add a new example "radiation" which visualizes the level of radiation of the cities of France on a geographical map.